### PR TITLE
add index to improve perf on resource data insert

### DIFF
--- a/azure-infrastructure/createViews.sql
+++ b/azure-infrastructure/createViews.sql
@@ -39,3 +39,10 @@ BEGIN
 		ON cost.application_resource_run_aggregation(measured_time_utc, application, wbs, run_id)
 END
 
+if EXISTS(select 1 from sys.views where object_id=OBJECT_ID('cost.application_resource_run_aggregation'))
+	AND NOT EXISTS(select 1 from sys.indexes WHERE object_id=OBJECT_ID('cost.ix_application_resource_run_aggregation_runid_app_wbs'))
+BEGIN
+	CREATE NONCLUSTERED INDEX ix_application_resource_run_aggregation_runid_app_wbs
+		ON [cost].[application_resource_run_aggregation] ([run_id],[application],[wbs])
+		INCLUDE ([cpu_millicores],[memory_mega_bytes],[row_count])
+END


### PR DESCRIPTION
The new index will increase performance when SQL Server updates the clustered view cost.application_resource_run_aggregation on changes in the underlying table cost.runs and cost.required_resources.

The execution plan will change from a Scan to an Index Seek
![image](https://user-images.githubusercontent.com/65334626/116369095-458d6b00-a809-11eb-8e65-06ab78bb0ea2.png)
![image](https://user-images.githubusercontent.com/65334626/116369292-81c0cb80-a809-11eb-8332-806261b66a39.png)

