### PR TITLE
Ignore logging containers without containerId

### DIFF
--- a/pkg/utils/dto/container.go
+++ b/pkg/utils/dto/container.go
@@ -25,7 +25,9 @@ func MapContainerBulkDtoFromPod(pod *corev1.Pod, rrMap map[string]*radixv1.Radix
 	environmentName := getEnvironmentNameFromNamespace(appName, pod.Namespace)
 
 	for _, containerStatus := range pod.Status.ContainerStatuses {
-		if containerStatus.State.Waiting != nil {
+		// Ignore containers in waiting state and containers without ContainerId
+		// ContainerId can be empty when Pod exceeds the activeDeadlineSeconds and is killed by K8S
+		if containerStatus.State.Waiting != nil || len(containerStatus.ContainerID) == 0 {
 			continue
 		}
 

--- a/pkg/utils/dto/container_test.go
+++ b/pkg/utils/dto/container_test.go
@@ -139,6 +139,23 @@ func TestMapContainerBulkDtoFromPod(t *testing.T) {
 		assert.Len(t, actual, 0)
 	})
 
+	// Pod, correct label, container missing Id
+	t.Run("correct label, container missing Id", func(t *testing.T) {
+		t.Parallel()
+		podName, env, node, app, containerName, containerId, startedAt, finishedAt :=
+			"pod1", "prod", "node1", "app1", "c1", "", time.Date(2020, 1, 1, 1, 1, 1, 0, time.UTC), time.Date(2020, 2, 1, 1, 1, 1, 0, time.UTC)
+		pod := buildPodForTest(podName, fmt.Sprintf("%s-%s", app, env), node,
+			setPodAppLabel(app),
+			appendPodContainerStatus(
+				buildContainerStatusForTest(containerName, containerId,
+					setContainerStateTerminated(containerId, startedAt, finishedAt),
+				),
+			),
+		)
+		actual := MapContainerBulkDtoFromPod(pod, make(map[string]*radixv1.RadixRegistration), make(map[string]*corev1.LimitRange), &clock.RealClock{})
+		assert.Len(t, actual, 0)
+	})
+
 	// Pod, correct label, missing resources, lr exist
 	t.Run("correct label, missing resources, lr exist", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
If Pods are terminated due to exceeding `activeDeadlineSeconds`, the `containerId` in `containerStatuses` can be empty if deadline is lower than the time it takes to start the container (e.g. 1 second).
containerId is used as primary key in db, and and containers without containerId must therefore be skipped