### PR TITLE
explicit database permissions

### DIFF
--- a/azure-infrastructure/createSchema.sql
+++ b/azure-infrastructure/createSchema.sql
@@ -9,3 +9,11 @@ BEGIN
 END
 
 GRANT EXEC ON SCHEMA::cost TO datawriter
+GRANT SELECT, INSERT, UPDATE, DELETE ON SCHEMA::cost TO datawriter
+
+IF NOT EXISTS(SELECT 1 FROM sys.database_principals WHERE principal_id = DATABASE_PRINCIPAL_ID('datareader'))
+BEGIN
+	CREATE ROLE datareader
+END
+
+GRANT SELECT ON SCHEMA::cost TO datareader

--- a/azure-infrastructure/createTypes.sql
+++ b/azure-infrastructure/createTypes.sql
@@ -7,6 +7,9 @@ BEGIN
 	)
 END
 
+GRANT EXEC ON TYPE::cost.node_upsert_type TO datareader
+
+
 IF NOT EXISTS(SELECT 1 FROM sys.table_types WHERE name='container_upsert_type' AND schema_id=SCHEMA_ID('cost'))
 BEGIN
 	CREATE TYPE cost.container_upsert_type AS TABLE(
@@ -25,3 +28,5 @@ BEGIN
 		PRIMARY KEY(container_id)
 	)
 END
+
+GRANT EXEC ON TYPE::cost.container_upsert_type TO datareader

--- a/azure-infrastructure/createTypes.sql
+++ b/azure-infrastructure/createTypes.sql
@@ -7,9 +7,6 @@ BEGIN
 	)
 END
 
-GRANT EXEC ON TYPE::cost.node_upsert_type TO datareader
-
-
 IF NOT EXISTS(SELECT 1 FROM sys.table_types WHERE name='container_upsert_type' AND schema_id=SCHEMA_ID('cost'))
 BEGIN
 	CREATE TYPE cost.container_upsert_type AS TABLE(
@@ -28,5 +25,3 @@ BEGIN
 		PRIMARY KEY(container_id)
 	)
 END
-
-GRANT EXEC ON TYPE::cost.container_upsert_type TO datareader


### PR DESCRIPTION
Add new role `datareader` to be used by cost allocation API. We'll create a new database user which will be member of this role. The user will be bootstrapped in radix-platform.

The `datawriter` role is granted CRUD permissions on the `cost` schema. User `radixwriter`, which is member of this role, can then be removed from the builtin roles `db_datareader` and `db_datawriter`.