### PR TITLE
fix processing of last termination state

### DIFF
--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.3.0
+appVersion: 0.3.1
 version: 0.6.0
 description: Pull cost data from containers and push to sql server
 name: radix-cost-allocation


### PR DESCRIPTION
In some (rare?) situations the state.terminated.containerID is empty, and lastState.terminated.containerID is equal to the "main" containerID. In these situations we must ignore state.terminated and instead treat lastState.terminated as the current state.

Below is an example where this situation occurs:
```
  containerStatuses:
  - containerID: containerd://b02eb48f66709aed50e0c29ff28b62cfbd9270f94753139f4c9204decdc0a975
    image: ...
    imageID: ...@sha256:201064dbf659284f4b2bfba65e9b085271424e602a4496289816182d2d897aa8
    lastState:
      terminated:
        containerID: containerd://b02eb48f66709aed50e0c29ff28b62cfbd9270f94753139f4c9204decdc0a975
        exitCode: 139
        finishedAt: "2023-03-27T20:26:04Z"
        reason: Error
        startedAt: "2023-03-27T20:26:01Z"
    name: backend
    ready: false
    restartCount: 777
    started: false
    state:
      terminated:
        exitCode: 137
        finishedAt: null
        message: The container could not be located when the pod was terminated
        reason: ContainerStatusUnknown
        startedAt: null
  hostIP: 10.7.8.176
  message: 'The node was low on resource: ephemeral-storage. '
  phase: Failed
  podIP: 10.7.9.11
  podIPs:
  - ip: 10.7.9.11
  qosClass: Burstable
  reason: Evicted
  startTime: "2023-03-25T02:07:13Z"
```

Normally, the lastState.terminated.containerID is different from the "main" containerID
```
  containerStatuses:
  - containerID: containerd://0018d31932ada9ea11a00ee6198bbc440300c11da19c190445306769a1c061eb
    image: radixdev.azurecr.io/radix-job-demo-server:pvcb2
    imageID: radixdev.azurecr.io/radix-job-demo-server@sha256:222f9372b766253f835e98fcf086fffc4cce36c676e086b7198489c7f3684acf
    lastState:
      terminated:
        containerID: containerd://372ee5af57e6bf944f1af2cfec00b82ca73a8d27716913587a02255df6610000
        exitCode: 0
        finishedAt: "2023-04-03T12:26:30Z"
        reason: Completed
        startedAt: "2023-04-03T12:24:16Z"
    name: server
    ready: false
    restartCount: 1
    started: false
    state:
      terminated:
        containerID: containerd://0018d31932ada9ea11a00ee6198bbc440300c11da19c190445306769a1c061eb
        exitCode: 0
        finishedAt: "2023-04-03T12:26:58Z"
        reason: Completed
        startedAt: "2023-04-03T12:26:31Z"
  hostIP: 10.9.2.37
  phase: Running
  podIP: 10.9.2.41
  podIPs:
  - ip: 10.9.2.41
  qosClass: Burstable
  startTime: "2023-04-03T12:24:11Z"
```
