### PR TITLE
remove outdated info in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,6 @@ We use arm template and github action to create azure resources
 The SQL Server database and objects are deployed on push to master and release branch.
 All SQL scripts on azure-infrastructure must be idempotent.
 
-Note: The Github Workflow is not allowed to create new external users, so you must run it locally. Se more here: https://github.com/equinor/radix-vulnerability-scanner/issues/54
-Workaround:
-```sh
-sqlcmd -S ${SERVER_NAME}.database.windows.net -d ${DATABASE_NAME} -G --variables RADIX_ZONE=${RADIX_ZONE} -i createSchema.sql
-```
-
 ## Deploy to cluster
 
 Installation on cluster is handled by flux through [flux repo](https://github.com/equinor/radix-flux). 


### PR DESCRIPTION
The cost-allocation servers are now configured with permission to query MS Graph, and the script that creates users from Azure managed identities now works.