### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,6 @@
 name: radix-cost-allocation-pr
+permissions:
+  contents: read
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/equinor/radix-cost-allocation/security/code-scanning/3](https://github.com/equinor/radix-cost-allocation/security/code-scanning/3)

The best way to fix this issue is to specify a `permissions` block with the minimum required privileges. Ideally, set this at the root level of the workflow YAML so all jobs inherit it, unless certain jobs require elevated privileges. Reviewing the given jobs (`build`, `test`, `lint`), none require write privileges; they only check out code and build/lint/test, so the minimal permission should be sufficient. According to GitHub’s documentation, `contents: read` is a safe starting point, which limits the GITHUB_TOKEN permissions to read-only access to repository contents.

To implement:  
- At the root of `.github/workflows/pr.yml`, after the `name:` line and before `on:`, add a `permissions:` block set to `contents: read`.  
- No imports or method/variable definitions are necessary for a YAML workflow fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
