### PR TITLE
chore: update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       pull-requests: read
       contents: read
-    uses: equinor/radix-reusable-workflows/.github/workflows/template-unreleased-pr-metadata.yml@v1.0.2
+    uses: equinor/radix-reusable-workflows/.github/workflows/template-unreleased-pr-metadata.yml@v1.1.0
     
   release-pull-request:
     name: Release pull request
@@ -25,7 +25,7 @@ jobs:
       pull-requests: write
       contents: read
       issues: write
-    uses: equinor/radix-reusable-workflows/.github/workflows/template-create-release-from-pr.yml@v1.0.2
+    uses: equinor/radix-reusable-workflows/.github/workflows/template-create-release-from-pr.yml@v1.1.0
     with:
       pull-request-number: ${{ matrix.pull-request-number }}
       use-github-app-token: true

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       pull-requests: read
       contents: read
-    uses: equinor/radix-reusable-workflows/.github/workflows/template-unreleased-pr-metadata.yml@v1.1.0
+    uses: equinor/radix-reusable-workflows/.github/workflows/template-unreleased-pr-metadata.yml@bbbf79dd34776ca9e9a4dc4fcf6dc643953f37e8 # v1.1.0
     
   release-pull-request:
     name: Release pull request
@@ -26,7 +26,7 @@ jobs:
       pull-requests: write
       contents: read
       issues: write
-    uses: equinor/radix-reusable-workflows/.github/workflows/template-create-release-from-pr.yml@v1.1.0
+    uses: equinor/radix-reusable-workflows/.github/workflows/template-create-release-from-pr.yml@bbbf79dd34776ca9e9a4dc4fcf6dc643953f37e8 # v1.1.0
     with:
       pull-request-number: ${{ matrix.pull-request-number }}
       use-github-app-token: true

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -5,6 +5,7 @@ on:
       - master
   workflow_dispatch:
   
+permissions: {}
 jobs:
   unreleased-prs-metadata:
     name: Get list of pending release pull requests

--- a/.github/workflows/deploy-database.yml
+++ b/.github/workflows/deploy-database.yml
@@ -59,7 +59,7 @@ jobs:
         Connection Timeout=30;
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: github.event.inputs.target == matrix.target.name
 
       - uses: azure/login@v2

--- a/.github/workflows/deploy-database.yml
+++ b/.github/workflows/deploy-database.yml
@@ -59,42 +59,42 @@ jobs:
         Connection Timeout=30;
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: github.event.inputs.target == matrix.target.name
 
-      - uses: azure/login@v2
+      - uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         if: github.event.inputs.target == matrix.target.name
         with:
           client-id: ${{matrix.target.client-id}}
           tenant-id: "3aa4a235-b6e2-48d5-9195-7fcf05b459b0"
           allow-no-subscriptions: true
 
-      - uses: azure/sql-action@v2.3
+      - uses: azure/sql-action@dae62750f3e645283b7755717b44a2029c0735fb # v2.3
         if: github.event.inputs.target == matrix.target.name
         with:
           connection-string: ${{env.connection}}
           path: "./azure-infrastructure/preDeployScript.sql"
 
-      - uses: azure/sql-action@v2.3
+      - uses: azure/sql-action@dae62750f3e645283b7755717b44a2029c0735fb # v2.3
         if: github.event.inputs.target == matrix.target.name
         with:
           connection-string: ${{env.connection}}
           path: "./azure-infrastructure/createSchema.sql"
           arguments: "-v RADIX_ZONE=${{matrix.target.name}}"
 
-      - uses: azure/sql-action@v2.3
+      - uses: azure/sql-action@dae62750f3e645283b7755717b44a2029c0735fb # v2.3
         if: github.event.inputs.target == matrix.target.name
         with:
           connection-string: ${{env.connection}}
           path: "./azure-infrastructure/createTables.sql"
 
-      - uses: azure/sql-action@v2.3
+      - uses: azure/sql-action@dae62750f3e645283b7755717b44a2029c0735fb # v2.3
         if: github.event.inputs.target == matrix.target.name
         with:
           connection-string: ${{env.connection}}
           path: "./azure-infrastructure/createTypes.sql"
 
-      - uses: azure/sql-action@v2.3
+      - uses: azure/sql-action@dae62750f3e645283b7755717b44a2029c0735fb # v2.3
         if: github.event.inputs.target == matrix.target.name
         with:
           connection-string: ${{env.connection}}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
       version: ${{ steps.metadata.outputs.version }}
       release-exist: ${{ steps.metadata.outputs.release_exist }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Metadata
         id: metadata
         env:
@@ -41,7 +41,7 @@ jobs:
     env:
       CONTAINER_REGISTRY: ghcr.io
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: docker/login-action@v3
         with:
           registry: ${{ env.CONTAINER_REGISTRY }}
@@ -74,7 +74,7 @@ jobs:
     env:
       HELM_CHART_REGISTRY: oci://ghcr.io
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Helm
         uses: azure/setup-helm@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,20 +42,20 @@ jobs:
       CONTAINER_REGISTRY: ghcr.io
     steps:
       - uses: actions/checkout@v6
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
         with:
           registry: ${{ env.CONTAINER_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
       - name: Container metadata
         id: container-metadata
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
         with:
           images: "${{ env.CONTAINER_REGISTRY }}/equinor/radix/cost-allocation"
           tags: ${{ needs.metadata.outputs.version }}
       - name: Build and push container images
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
         with:
           context: .
           push: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+' # semver stable
       - 'v[0-9]+.[0-9]+.[0-9]+-*' # semver with prerelease suffix
+permissions: {}
 jobs:
   metadata:
     runs-on: ubuntu-latest
@@ -13,7 +14,7 @@ jobs:
       version: ${{ steps.metadata.outputs.version }}
       release-exist: ${{ steps.metadata.outputs.release_exist }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Metadata
         id: metadata
         env:
@@ -41,21 +42,21 @@ jobs:
     env:
       CONTAINER_REGISTRY: ghcr.io
     steps:
-      - uses: actions/checkout@v6
-      - uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ${{ env.CONTAINER_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - name: Container metadata
         id: container-metadata
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: "${{ env.CONTAINER_REGISTRY }}/equinor/radix/cost-allocation"
           tags: ${{ needs.metadata.outputs.version }}
       - name: Build and push container images
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
           push: true
@@ -74,9 +75,9 @@ jobs:
     env:
       HELM_CHART_REGISTRY: oci://ghcr.io
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
           version: v3.18.3
       - name: Helm login

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,11 +10,11 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - name: Build and push Docker image
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
           push: false
@@ -26,8 +26,8 @@ jobs:
     name: Unit Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: "go.mod"
       - name: Install dependencies
@@ -39,10 +39,10 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 2
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: "go.mod"
       - name: golangci-lint

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,7 +10,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build and push Docker image
@@ -26,7 +26,7 @@ jobs:
     name: Unit Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
@@ -39,7 +39,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 2
       - uses: actions/setup-go@v5

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,9 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25
         with:
           context: .
           push: false

--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -7,6 +7,7 @@ on:
       - master
   workflow_dispatch:
 
+permissions: {}
 concurrency:
   group: ${{ github.workflow }}
 

--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   prepare-release-pr:
     name: Prepare release pull request
-    uses: equinor/radix-reusable-workflows/.github/workflows/template-prepare-release-pr.yml@v1.0.2
+    uses: equinor/radix-reusable-workflows/.github/workflows/template-prepare-release-pr.yml@bbbf79dd34776ca9e9a4dc4fcf6dc643953f37e8 # v1.1.0
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Update deprecated GitHub Actions to versions compatible with Node.js 24.\n\n- Update actions/checkout to v6\n- Update radix-reusable-workflows to v1.1.0\n\nNode.js 20 actions are deprecated and will be forced to run with Node.js 24 by default starting June 2nd, 2026.